### PR TITLE
Fixed messagepack overflow if player owns too many vehicles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # esx_eden_garage
 Garage privé basé sur ESX
 
-Requirement : 
+Requirement :
 fxserver-esx_vehicleshop
 
 Le garage prends en compte uniquement les véhicules achetés dans le concessionaire et aussi les véhicules qui sont dehors ou non.
@@ -16,8 +16,7 @@ BUG CONNU :
 - Certains véhicules sont impossible à rentrer
 - En cherchant bien il est possible de dupliquer les véhicules
 
-Nous travaillons dessus. 
+Nous travaillons dessus.
 
 Fonctionnement :
 Entrez dans le cercle vert a pied pour sortir un vehicule, entre dans le cercle rouge avec votre vehicule pour le rentrer si le vehicule est endomagé un menu vous annonce le montant de la facture vous pouvez la payer pour rentrer le vehicule ou aller voir un mécano
-

--- a/client.lua
+++ b/client.lua
@@ -1,19 +1,4 @@
--- Local
-local Keys = {
-	["ESC"] = 322, ["F1"] = 288, ["F2"] = 289, ["F3"] = 170, ["F5"] = 166, ["F6"] = 167, ["F7"] = 168, ["F8"] = 169, ["F9"] = 56, ["F10"] = 57, 
-	["~"] = 243, ["1"] = 157, ["2"] = 158, ["3"] = 160, ["4"] = 164, ["5"] = 165, ["6"] = 159, ["7"] = 161, ["8"] = 162, ["9"] = 163, ["-"] = 84, ["="] = 83, ["BACKSPACE"] = 177, 
-	["TAB"] = 37, ["Q"] = 44, ["W"] = 32, ["E"] = 38, ["R"] = 45, ["T"] = 245, ["Y"] = 246, ["U"] = 303, ["P"] = 199, ["["] = 39, ["]"] = 40, ["ENTER"] = 18,
-	["CAPS"] = 137, ["A"] = 34, ["S"] = 8, ["D"] = 9, ["F"] = 23, ["G"] = 47, ["H"] = 74, ["K"] = 311, ["L"] = 182,
-	["LEFTSHIFT"] = 21, ["Z"] = 20, ["X"] = 73, ["C"] = 26, ["V"] = 0, ["B"] = 29, ["N"] = 249, ["M"] = 244, [","] = 82, ["."] = 81,
-	["LEFTCTRL"] = 36, ["LEFTALT"] = 19, ["SPACE"] = 22, ["RIGHTCTRL"] = 70, 
-	["HOME"] = 213, ["PAGEUP"] = 10, ["PAGEDOWN"] = 11, ["DELETE"] = 178,
-	["LEFT"] = 174, ["RIGHT"] = 175, ["TOP"] = 27, ["DOWN"] = 173,
-	["NENTER"] = 201, ["N4"] = 108, ["N5"] = 60, ["N6"] = 107, ["N+"] = 96, ["N-"] = 97, ["N7"] = 117, ["N8"] = 61, ["N9"] = 118
-}
-
 local CurrentAction = nil
-local GUI                       = {}
-GUI.Time                        = 0
 local HasAlreadyEnteredMarker   = false
 local LastZone                  = nil
 local CurrentActionMsg          = ''
@@ -38,14 +23,14 @@ end)
 --- Gestion Des blips
 RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(xPlayer)
-    --PlayerData = xPlayer
-    --TriggerServerEvent('esx_jobs:giveBackCautionInCaseOfDrop')
-    refreshBlips()
+	--PlayerData = xPlayer
+	--TriggerServerEvent('esx_jobs:giveBackCautionInCaseOfDrop')
+	refreshBlips()
 end)
 
 function refreshBlips()
 	local zones = {}
-	local blipInfo = {}	
+	local blipInfo = {}
 
 	for zoneKey,zoneValues in pairs(Config.Garages)do
 
@@ -58,7 +43,7 @@ function refreshBlips()
 		BeginTextCommandSetBlipName("STRING")
 		AddTextComponentString(zoneKey)
 		EndTextCommandSetBlipName(blip)
-		
+
 		local blip = AddBlipForCoord(zoneValues.MunicipalPoundPoint.Pos.x, zoneValues.MunicipalPoundPoint.Pos.y, zoneValues.MunicipalPoundPoint.Pos.z)
 		SetBlipSprite (blip, Config.BlipPound.Sprite)
 		SetBlipDisplay(blip, 4)
@@ -80,7 +65,7 @@ function OpenMenuGarage(PointType)
 
 	local elements = {}
 
-	
+
 	if PointType == 'spawn' then
 		table.insert(elements,{label = "Liste des véhicules", value = 'list_vehicles'})
 	end
@@ -119,9 +104,9 @@ function OpenMenuGarage(PointType)
 		end,
 		function(data, menu)
 			menu.close()
-			
+
 		end
-	)	
+	)
 end
 
 
@@ -134,17 +119,17 @@ function ListVehiclesMenu()
 		for _,v in pairs(vehicles) do
 
 			local hashVehicule = v.vehicle.model
-    		local vehicleName = GetDisplayNameFromVehicleModel(hashVehicule)
-    		local labelvehicle
+			local vehicleName = GetDisplayNameFromVehicleModel(hashVehicule)
+			local labelvehicle
 
-    		if(v.state)then
-    		labelvehicle = vehicleName..': Garage'
-    		
-    		else
-    		labelvehicle = vehicleName..': Fourriere'
-    		end	
+			if(v.state)then
+			labelvehicle = vehicleName..': Garage'
+
+			else
+			labelvehicle = vehicleName..': Fourriere'
+			end
 			table.insert(elements, {label =labelvehicle , value = v})
-			
+
 		end
 
 		ESX.UI.Menu.Open(
@@ -166,12 +151,12 @@ function ListVehiclesMenu()
 			menu.close()
 			--CurrentAction = 'open_garage_action'
 		end
-	)	
+	)
 	end)
 end
 -- Fin Afficher les listes des vehicules
 function reparation(prix,vehicle,vehicleProps)
-	
+
 	ESX.UI.Menu.CloseAll()
 
 	local elements = {
@@ -199,9 +184,9 @@ function reparation(prix,vehicle,vehicleProps)
 		end,
 		function(data, menu)
 			menu.close()
-			
+
 		end
-	)	
+	)
 end
 
 function ranger(vehicle,vehicleProps)
@@ -216,8 +201,8 @@ function StockVehicleMenu()
 	if IsPedInAnyVehicle(playerPed,  false) then
 
 		local playerPed = GetPlayerPed(-1)
-    	local coords    = GetEntityCoords(playerPed)
-    	local vehicle =GetVehiclePedIsIn(playerPed,false)     
+		local coords    = GetEntityCoords(playerPed)
+		local vehicle =GetVehiclePedIsIn(playerPed,false)
 		local vehicleProps  = ESX.Game.GetVehicleProperties(vehicle)
 		local current 	    = GetPlayersLastVehicle(GetPlayerPed(-1), true)
 		local engineHealth  = GetVehicleEngineHealth(current)
@@ -228,11 +213,11 @@ function StockVehicleMenu()
 				TriggerServerEvent('eden_garage:debug', "plaque vehicule rentree au garage: "  .. vehicleProps.plate)
 				TriggerServerEvent('eden_garage:logging',"santee vehicule rentree au garage: " .. engineHealth)
 				if engineHealth < 1000 then
-			        local fraisRep= math.floor((1000 - engineHealth)*100)
+					local fraisRep= math.floor((1000 - engineHealth)*100)
 				reparation(fraisRep,vehicle,vehicleProps)
-			    else
-			    	ranger(vehicle,vehicleProps)
-			    end	
+				else
+					ranger(vehicle,vehicleProps)
+				end
 			else
 				TriggerEvent('esx:showNotification', 'Vous ne pouvez pas stocker ce véhicule')
 			end
@@ -242,7 +227,7 @@ function StockVehicleMenu()
 	end
 
 end
--- Fin fonction qui permet de rentrer un vehicule 
+-- Fin fonction qui permet de rentrer un vehicule
 --Fin fonction Menu
 
 
@@ -252,7 +237,7 @@ function SpawnVehicle(vehicle)
 	ESX.Game.SpawnVehicle(vehicle.model,{
 		x=this_Garage.SpawnPoint.Pos.x ,
 		y=this_Garage.SpawnPoint.Pos.y,
-		z=this_Garage.SpawnPoint.Pos.z + 1											
+		z=this_Garage.SpawnPoint.Pos.z + 1
 		},this_Garage.SpawnPoint.Heading, function(callback_vehicle)
 		ESX.Game.SetVehicleProperties(callback_vehicle, vehicle)
 		SetVehRadioStation(callback_vehicle, "OFF")
@@ -260,7 +245,7 @@ function SpawnVehicle(vehicle)
 		local plate = GetVehicleNumberPlateText(callback_vehicle)
 		TriggerServerEvent("ls:mainCheck", plate, callback_vehicle, true)
 		end)
-		
+
 
 	TriggerServerEvent('eden_garage:modifystate', vehicle, false)
 
@@ -273,7 +258,7 @@ function SpawnPoundedVehicle(vehicle)
 	ESX.Game.SpawnVehicle(vehicle.model, {
 		x = this_Garage.SpawnMunicipalPoundPoint.Pos.x ,
 		y = this_Garage.SpawnMunicipalPoundPoint.Pos.y,
-		z = this_Garage.SpawnMunicipalPoundPoint.Pos.z + 1											
+		z = this_Garage.SpawnMunicipalPoundPoint.Pos.z + 1
 		},180, function(callback_vehicle)
 		ESX.Game.SetVehicleProperties(callback_vehicle, vehicle)
 		local plate = GetVehicleNumberPlateText(callback_vehicle)
@@ -301,7 +286,7 @@ AddEventHandler('eden_garage:hasEnteredMarker', function(zone)
 		CurrentActionMsg  = "Appuyer sur ~INPUT_PICKUP~ pour rentrer un vehicule"
 		CurrentActionData = {}
 	end
-	
+
 	if zone == 'pound' then
 		CurrentAction     = 'pound_action_menu'
 		CurrentActionMsg  = "Appuyer sur ~INPUT_PICKUP~ pour acceder a la fourriere"
@@ -324,13 +309,13 @@ function ReturnVehicleMenu()
 		for _,v in pairs(vehicles) do
 
 			local hashVehicule = v.model
-    		local vehicleName = GetDisplayNameFromVehicleModel(hashVehicule)
-    		local labelvehicle
+			local vehicleName = GetDisplayNameFromVehicleModel(hashVehicule)
+			local labelvehicle
 
-    		labelvehicle = vehicleName..': Sortie'
-    	
+			labelvehicle = vehicleName..': Sortie'
+
 			table.insert(elements, {label =labelvehicle , value = v})
-			
+
 		end
 
 		ESX.UI.Menu.Open(
@@ -341,10 +326,10 @@ function ReturnVehicleMenu()
 			elements = elements,
 		},
 		function(data, menu)
-	
+
 			ESX.TriggerServerCallback('eden_garage:checkMoney', function(hasEnoughMoney)
 				if hasEnoughMoney then
-					
+
 					if times == 0 then
 						TriggerServerEvent('eden_garage:pay')
 						SpawnPoundedVehicle(data.current.value)
@@ -355,7 +340,7 @@ function ReturnVehicleMenu()
 						end)
 					end
 				else
-					ESX.ShowNotification('Vous n\'avez pas assez d\'argent')						
+					ESX.ShowNotification('Vous n\'avez pas assez d\'argent')
 				end
 			end)
 		end,
@@ -363,26 +348,26 @@ function ReturnVehicleMenu()
 			menu.close()
 			--CurrentAction = 'open_garage_action'
 		end
-		)	
+		)
 	end)
 end
 
 -- Affichage markers
 Citizen.CreateThread(function()
 	while true do
-		Wait(0)		
-		local coords = GetEntityCoords(GetPlayerPed(-1))			
+		Wait(0)
+		local coords = GetEntityCoords(GetPlayerPed(-1))
 
 		for k,v in pairs(Config.Garages) do
-			if(GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < Config.DrawDistance) then		
-				DrawMarker(v.SpawnPoint.Marker, v.SpawnPoint.Pos.x, v.SpawnPoint.Pos.y, v.SpawnPoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.SpawnPoint.Size.x, v.SpawnPoint.Size.y, v.SpawnPoint.Size.z, v.SpawnPoint.Color.r, v.SpawnPoint.Color.g, v.SpawnPoint.Color.b, 100, false, true, 2, false, false, false, false)	
-				DrawMarker(v.DeletePoint.Marker, v.DeletePoint.Pos.x, v.DeletePoint.Pos.y, v.DeletePoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.DeletePoint.Size.x, v.DeletePoint.Size.y, v.DeletePoint.Size.z, v.DeletePoint.Color.r, v.DeletePoint.Color.g, v.DeletePoint.Color.b, 100, false, true, 2, false, false, false, false)	
+			if(GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < Config.DrawDistance) then
+				DrawMarker(v.SpawnPoint.Marker, v.SpawnPoint.Pos.x, v.SpawnPoint.Pos.y, v.SpawnPoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.SpawnPoint.Size.x, v.SpawnPoint.Size.y, v.SpawnPoint.Size.z, v.SpawnPoint.Color.r, v.SpawnPoint.Color.g, v.SpawnPoint.Color.b, 100, false, true, 2, false, false, false, false)
+				DrawMarker(v.DeletePoint.Marker, v.DeletePoint.Pos.x, v.DeletePoint.Pos.y, v.DeletePoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.DeletePoint.Size.x, v.DeletePoint.Size.y, v.DeletePoint.Size.z, v.DeletePoint.Color.r, v.DeletePoint.Color.g, v.DeletePoint.Color.b, 100, false, true, 2, false, false, false, false)
 			end
 			if(GetDistanceBetweenCoords(coords, v.MunicipalPoundPoint.Pos.x, v.MunicipalPoundPoint.Pos.y, v.MunicipalPoundPoint.Pos.z, true) < Config.DrawDistance) then
-				DrawMarker(v.MunicipalPoundPoint.Marker, v.MunicipalPoundPoint.Pos.x, v.MunicipalPoundPoint.Pos.y, v.MunicipalPoundPoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.MunicipalPoundPoint.Size.x, v.MunicipalPoundPoint.Size.y, v.MunicipalPoundPoint.Size.z, v.MunicipalPoundPoint.Color.r, v.MunicipalPoundPoint.Color.g, v.MunicipalPoundPoint.Color.b, 100, false, true, 2, false, false, false, false)	
+				DrawMarker(v.MunicipalPoundPoint.Marker, v.MunicipalPoundPoint.Pos.x, v.MunicipalPoundPoint.Pos.y, v.MunicipalPoundPoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.MunicipalPoundPoint.Size.x, v.MunicipalPoundPoint.Size.y, v.MunicipalPoundPoint.Size.z, v.MunicipalPoundPoint.Color.r, v.MunicipalPoundPoint.Color.g, v.MunicipalPoundPoint.Color.b, 100, false, true, 2, false, false, false, false)
 				DrawMarker(v.SpawnMunicipalPoundPoint.Marker, v.SpawnMunicipalPoundPoint.Pos.x, v.SpawnMunicipalPoundPoint.Pos.y, v.SpawnMunicipalPoundPoint.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.SpawnMunicipalPoundPoint.Size.x, v.SpawnMunicipalPoundPoint.Size.y, v.SpawnMunicipalPoundPoint.Size.z, v.SpawnMunicipalPoundPoint.Color.r, v.SpawnMunicipalPoundPoint.Color.g, v.SpawnMunicipalPoundPoint.Color.b, 100, false, true, 2, false, false, false, false)
-			end		
-		end	
+			end
+		end
 	end
 end)
 -- Fin affichage markers
@@ -445,7 +430,7 @@ Citizen.CreateThread(function()
 			AddTextComponentString(CurrentActionMsg)
 			DisplayHelpTextFromStringLabel(0, 0, 1, -1)
 
-			if IsControlPressed(0,  Keys['E']) and (GetGameTimer() - GUI.Time) > 150 then
+			if IsControlJustReleased(0, 38) then
 
 				if CurrentAction == 'pound_action_menu' then
 					OpenMenuGarage('pound')
@@ -459,8 +444,6 @@ Citizen.CreateThread(function()
 
 
 				CurrentAction = nil
-				GUI.Time      = GetGameTimer()
-
 			end
 		end
 	end

--- a/config.lua
+++ b/config.lua
@@ -4,16 +4,16 @@ Config = {
 	Price = 3000,
 	BlipInfos = {
 		Sprite = 290,
-		Color = 38 
+		Color = 38
 	},
 	BlipPound = {
 		Sprite = 67,
-		Color = 64 
+		Color = 64
 	}
 }
 
 Config.Garages = {
-	Garage_Centre = {	
+	Garage_Centre = {
 		Pos = {x=215.800, y=-810.057, z=29.727},
 		Size  = {x = 3.0, y = 3.0, z = 1.0},
 		Color = {r = 204, g = 204, b = 0},
@@ -23,14 +23,14 @@ Config.Garages = {
 			Color = {r=0,g=255,b=0},
 			Size  = {x = 3.0, y = 3.0, z = 1.0},
 			Heading=157.84,
-			Marker = 1		
+			Marker = 1
 		},
 		DeletePoint = {
 			Pos = {x=215.124, y=-791.377, z=29.646},
 			Color = {r=255,g=0,b=0},
 			Size  = {x = 3.0, y = 3.0, z = 1.0},
 			Marker = 1,
-			
+
 		},
 		MunicipalPoundPoint = {
 			Pos = {x=482.896, y=-1316.557, z=28.301},
@@ -46,7 +46,7 @@ Config.Garages = {
 			Heading=299.42
 		},
 	},
-	Garage_Paleto = {	
+	Garage_Paleto = {
 		Pos = {x=105.359, y=6613.586, z=31.3973},
 		Size  = {x = 3.0, y = 3.0, z = 1.0},
 		Color = {r = 204, g = 204, b = 0},
@@ -68,7 +68,7 @@ Config.Garages = {
 			Color = {r=25,g=25,b=112},
 			Size  = {x = 3.0, y = 3.0, z = 1.0},
 			Marker = 1
-		},	
+		},
 		SpawnMunicipalPoundPoint = {
 			Pos = {x=-199.160, y=6274.180, z=30.580},
 			Color = {r=0,g=255,b=0},
@@ -76,7 +76,7 @@ Config.Garages = {
 			Marker = 1
 		},
 	},
-	Garage_Poissoniers = {	
+	Garage_Poissoniers = {
 		Pos = {x = -1511.6556396484,y = 5009.875,z = 61.800533294678 },
 		Size  = {x = 3.0, y = 3.0, z = 1.0},
 		Color = {r = 204, g = 204, b = 0},
@@ -98,7 +98,7 @@ Config.Garages = {
 			Color = {r=25,g=25,b=112},
 			Size  = {x = 3.0, y = 3.0, z = 1.0},
 			Marker = 1
-		},	
+		},
 		SpawnMunicipalPoundPoint = {
 			Pos = {x = -2205.4594726563,y = 4247.3603515625,z = 46.639003753662 },
 			Color = {r=0,g=255,b=0},
@@ -106,7 +106,7 @@ Config.Garages = {
 			Marker = 1
 		},
 	},
-	Garage_SandyShore = {	
+	Garage_SandyShore = {
 		Pos = {x = 1979.3223876953,y = 3828.7197265625,z = 31.394721984863 },
 		Size  = {x = 3.0, y = 3.0, z = 1.0},
 		Color = {r = 204, g = 204, b = 0},
@@ -128,7 +128,7 @@ Config.Garages = {
 			Color = {r=25,g=25,b=112},
 			Size  = {x = 3.0, y = 3.0, z = 1.0},
 			Marker = 1
-		},	
+		},
 		SpawnMunicipalPoundPoint = {
 			Pos = {x = 1551.8347167969,y = 3518.1003417969,z = 34.988235473633 },
 			Color = {r=0,g=255,b=0},
@@ -136,7 +136,7 @@ Config.Garages = {
 			Marker = 1
 		},
 	},
-		Garage_Aeroport = {	
+		Garage_Aeroport = {
 		Pos = {x = -977.21661376953,y = -2710.3798828125,z = 12.853487014771 },
 		Size  = {x = 3.0, y = 3.0, z = 1.0},
 		Color = {r = 204, g = 204, b = 0},
@@ -158,7 +158,7 @@ Config.Garages = {
 			Color = {r=25,g=25,b=112},
 			Size  = {x = 3.0, y = 3.0, z = 1.0},
 			Marker = 1
-		},	
+		},
 		SpawnMunicipalPoundPoint = {
 			Pos = {x = -1048.3468017578,y = -2669.771484375,z = 12.830758094788 },
 			Color = {r=0,g=255,b=0},

--- a/server.lua
+++ b/server.lua
@@ -4,11 +4,9 @@ RegisterServerEvent('eden_garage:pay')
 RegisterServerEvent('eden_garage:payhealth')
 RegisterServerEvent('eden_garage:logging')
 
-
-ESX                = nil
+ESX = nil
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-
 
 --Recupere les véhicules
 ESX.RegisterServerCallback('eden_garage:getVehicles', function(source, cb)
@@ -16,7 +14,7 @@ ESX.RegisterServerCallback('eden_garage:getVehicles', function(source, cb)
 	local xPlayer = ESX.GetPlayerFromId(_source)
 	local vehicules = {}
 
-	MySQL.Async.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier",{['@identifier'] = xPlayer.getIdentifier()}, function(data) 
+	MySQL.Async.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier",{['@identifier'] = xPlayer.getIdentifier()}, function(data)
 		for _,v in pairs(data) do
 			local vehicle = json.decode(v.vehicle)
 			table.insert(vehicules, {vehicle = vehicle, state = v.state})
@@ -33,8 +31,7 @@ ESX.RegisterServerCallback('eden_garage:stockv',function(source,cb, vehicleProps
 	local xPlayer = ESX.GetPlayerFromId(_source)
 	local vehicules = getPlayerVehicles(xPlayer.getIdentifier())
 	local plate = vehicleProps.plate
-	print(plate)
-	
+
 		for _,v in pairs(vehicules) do
 			if(plate == v.plate)then
 				local idveh = v.id
@@ -42,7 +39,7 @@ ESX.RegisterServerCallback('eden_garage:stockv',function(source,cb, vehicleProps
 				MySQL.Sync.execute("UPDATE owned_vehicles SET vehicle =@vehprop WHERE id=@id",{['@vehprop'] = vehprop, ['@id'] = v.id})
 				isFound = true
 				break
-			end		
+			end
 		end
 		cb(isFound)
 end)
@@ -64,9 +61,9 @@ AddEventHandler('eden_garage:modifystate', function(vehicleProps, state)
 			local idveh = v.id
 			MySQL.Sync.execute("UPDATE owned_vehicles SET state =@state WHERE id=@id",{['@state'] = state , ['@id'] = v.id})
 			break
-		end		
+		end
 	end
-end)	
+end)
 
 
 
@@ -76,12 +73,12 @@ end)
 
 -- Fin Fonction qui récupere les plates
 
-ESX.RegisterServerCallback('eden_garage:getOutVehicles',function(source, cb)	
+ESX.RegisterServerCallback('eden_garage:getOutVehicles',function(source, cb)
 	local _source = source
 	local xPlayer = ESX.GetPlayerFromId(_source)
 	local vehicules = {}
 
-	MySQL.Async.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier AND state=false",{['@identifier'] = xPlayer.getIdentifier()}, function(data) 
+	MySQL.Async.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier AND state=false",{['@identifier'] = xPlayer.getIdentifier()}, function(data)
 		for _,v in pairs(data) do
 			local vehicle = json.decode(v.vehicle)
 			table.insert(vehicules, vehicle)
@@ -120,9 +117,9 @@ end)
 
 --Recupere les vehicules
 function getPlayerVehicles(identifier)
-	
+
 	local vehicles = {}
-	local data = MySQL.Sync.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier",{['@identifier'] = identifier})	
+	local data = MySQL.Sync.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier",{['@identifier'] = identifier})
 	for _,v in pairs(data) do
 		local vehicle = json.decode(v.vehicle)
 		table.insert(vehicles, {id = v.id, plate = vehicle.plate})

--- a/server.lua
+++ b/server.lua
@@ -12,14 +12,11 @@ TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 ESX.RegisterServerCallback('eden_garage:getVehicles', function(source, cb)
 	local _source = source
 	local xPlayer = ESX.GetPlayerFromId(_source)
-	local vehicules = {}
 
-	MySQL.Async.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier",{['@identifier'] = xPlayer.getIdentifier()}, function(data)
-		for _,v in pairs(data) do
-			local vehicle = json.decode(v.vehicle)
-			table.insert(vehicules, {vehicle = vehicle, state = v.state})
-		end
-		cb(vehicules)
+	MySQL.Async.fetchAll('SELECT vehicle, state, job FROM owned_vehicles WHERE owner = @identifier', {
+		['@identifier'] = xPlayer.identifier
+	}, function(result)
+		cb(result)
 	end)
 end)
 -- Fin --Recupere les véhicules
@@ -74,16 +71,12 @@ end)
 -- Fin Fonction qui récupere les plates
 
 ESX.RegisterServerCallback('eden_garage:getOutVehicles',function(source, cb)
-	local _source = source
-	local xPlayer = ESX.GetPlayerFromId(_source)
-	local vehicules = {}
+	local xPlayer = ESX.GetPlayerFromId(source)
 
-	MySQL.Async.fetchAll("SELECT * FROM owned_vehicles WHERE owner=@identifier AND state=false",{['@identifier'] = xPlayer.getIdentifier()}, function(data)
-		for _,v in pairs(data) do
-			local vehicle = json.decode(v.vehicle)
-			table.insert(vehicules, vehicle)
-		end
-		cb(vehicules)
+	MySQL.Async.fetchAll('SELECT * FROM owned_vehicles WHERE owner = @identifier AND state = false', {
+		['@identifier'] = xPlayer.getIdentifier()
+	}, function(result)
+		cb(result)
 	end)
 end)
 


### PR DESCRIPTION
The messagepack error is a error message since we are parsing way too much data trough the NUI.
There's an limit as to how much data you can transmit (at once).

This commit moves the vehicle props which  previously was parsed to NUI to a table with plate as keys and values being the vehicle props.
This way we wont reach any limit any time soon.

Also this has minor performance improvements on the server side since we no longer decode vehicles on the server!